### PR TITLE
switch to once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ alga = "0.9"
 nalgebra = "0.22"
 rand = "0.7"
 rayon = "1.2"
-lazy_static = "1.4"
+once_cell = "1.4"
 bbox = "0.11"
 num-traits = "0.2"
 

--- a/src/manifold_dual_contouring.rs
+++ b/src/manifold_dual_contouring.rs
@@ -99,8 +99,9 @@ const QUADS: [[Edge; 4]; 3] = [
     [Edge::C, Edge::I, Edge::L, Edge::F],
 ];
 
-lazy_static::lazy_static! {
-    static ref OUTSIDE_EDGES_PER_CORNER: [BitSet; 8] = [
+use once_cell::sync::Lazy;
+static OUTSIDE_EDGES_PER_CORNER: Lazy<[BitSet; 8]> = Lazy::new(|| {
+    [
         BitSet::from_3bits(0, 1, 2),
         BitSet::from_3bits(0, 4, 5),
         BitSet::from_3bits(1, 3, 8),
@@ -108,9 +109,9 @@ lazy_static::lazy_static! {
         BitSet::from_3bits(2, 6, 7),
         BitSet::from_3bits(5, 6, 10),
         BitSet::from_3bits(7, 8, 9),
-        BitSet::from_3bits(9, 10, 11)
-    ];
-}
+        BitSet::from_3bits(9, 10, 11),
+    ]
+});
 
 #[derive(Debug)]
 pub enum DualContouringError {

--- a/src/vertex_index.rs
+++ b/src/vertex_index.rs
@@ -15,16 +15,17 @@ use crate::bitset::BitSet;
 //  o-------0-------+         +-- higher indexes in x ---->
 
 // Face order X0, X1, Y0, Y1, Z0, Z1
-lazy_static::lazy_static! {
-    pub static ref EDGES_ON_FACE: [BitSet; 6] = [
+use once_cell::sync::Lazy;
+pub static EDGES_ON_FACE: Lazy<[BitSet; 6]> = Lazy::new(|| {
+    [
         BitSet::from_4bits(1, 2, 7, 8),
         BitSet::from_4bits(4, 5, 10, 11),
         BitSet::from_4bits(0, 2, 5, 6),
         BitSet::from_4bits(3, 8, 9, 11),
         BitSet::from_4bits(0, 1, 3, 4),
-        BitSet::from_4bits(6, 7, 9, 10)
-    ];
-}
+        BitSet::from_4bits(6, 7, 9, 10),
+    ]
+});
 
 fn egdes_on_neighbor(neighbor_index: usize, edges: BitSet) -> BitSet {
     let bits = edges.intersect(EDGES_ON_FACE[neighbor_index]).as_u32();


### PR DESCRIPTION
Because once_cell does not use macros and may thus be more readable and will potentially be included in std and thus would remove a dependency I'd propose to move to that.

Performance may need to be measured.