### PR TITLE
Add support for wasm32 target & silence arithmetic error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,14 @@ license = "Apache-2.0 OR MIT"
 name = "tessellation"
 path = "src/lib.rs"
 
+[features]
+default = ["wasm-bindgen"]
+stdweb = ["instant/stdweb"]
+wasm-bindgen = ["instant/wasm-bindgen"]
+
 [dependencies]
 alga = "0.9"
+instant = "0.1"
 nalgebra = "0.22"
 rand = "0.7"
 rayon = "1.2"

--- a/src/manifold_dual_contouring.rs
+++ b/src/manifold_dual_contouring.rs
@@ -398,17 +398,17 @@ fn subsample_octtree<S: RealField + Float + From<f32>>(base: &[Vertex<S>]) -> Ve
 }
 
 struct Timer {
-    t: std::time::Instant,
+    t: instant::Instant,
 }
 
 impl Timer {
     fn new() -> Timer {
         Timer {
-            t: std::time::Instant::now(),
+            t: instant::Instant::now(),
         }
     }
     fn elapsed(&mut self) -> std::time::Duration {
-        let now = std::time::Instant::now();
+        let now = instant::Instant::now();
         let result = now - self.t;
         self.t = now;
         result

--- a/src/manifold_dual_contouring.rs
+++ b/src/manifold_dual_contouring.rs
@@ -10,6 +10,7 @@ use crate::{
 use bbox::BoundingBox;
 use nalgebra as na;
 use num_traits::Float;
+#[cfg(not(target_arch="wasm32"))]
 use rayon::prelude::*;
 use std::{
     cell::{Cell, RefCell},
@@ -607,8 +608,11 @@ impl<'a, S: From<f32> + RealField + Float + AsUSize> ManifoldDualContouring<'a, 
     fn compact_value_grid(&mut self) {
         // Collect all indexes to remove.
         let value_grid = &mut self.value_grid;
-        let keys_to_remove: Vec<_> = value_grid
-            .par_iter()
+        #[cfg(not(target_arch="wasm32"))]
+        let value_grid_iter = value_grid.par_iter();
+        #[cfg(target_arch="wasm32")]
+        let value_grid_iter = value_grid.iter();
+        let keys_to_remove: Vec<_> = value_grid_iter
             .filter(|&(idx, &v)| {
                 if idx[0] == 0 || idx[1] == 0 || idx[2] == 0 {
                     // This grid cell does not have neighbors in some directions. Ignore.

--- a/src/manifold_dual_contouring.rs
+++ b/src/manifold_dual_contouring.rs
@@ -231,7 +231,7 @@ fn pow2roundup(x: usize) -> usize {
     x |= x >> 4;
     x |= x >> 8;
     x |= x >> 16;
-    x |= x >> 32;
+    x |= x.wrapping_shr(32);
     x + 1
 }
 


### PR DESCRIPTION
Hello! Thank you so much for the awesome library.

I've started using it in a game I'm developing with the Bevy engine (really all I have right is a sphere).
Your library was super simple to get started with and works really well so far.

The only issue I had was rayon and `std::time` don't work on the wasm32 target yet so I needed to disable those to get it to work in the browser.

Adding `cfg(not(target_arch = "wasm32"))` everywhere the timer & rayon were used got it working for me.