### PR TITLE
Upgrade dependencies and switch from alga to simba

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ name = "tessellation"
 path = "src/lib.rs"
 
 [dependencies]
-alga = "0.9"
-nalgebra = "0.22"
-rand = "0.7"
-rayon = "1.2"
-once_cell = "1.4"
-bbox = "0.11"
-num-traits = "0.2"
+bbox = "0.11.2"
+nalgebra = "0.27.1"
+num-traits = "0.2.14"
+once_cell = "1.7.2"
+rand = "0.8.3"
+rayon = "1.5.1"
+simba = "0.5.1"
 
 [dev-dependencies]
-approx = "0.3"
-bencher = "0.1"
-implicit3d = "0.14"
+approx = "0.5.0"
+bencher = "0.1.5"
+implicit3d = "0.14.2"
 
 [[bench]]
 name = "tessellation"
@@ -36,3 +36,7 @@ harness = false
 [badges]
 travis-ci = { repository = "hmeyer/tessellation", branch = "master" }
 codecov = { repository = "hmeyer/tessellation", branch = "master", service = "github" }
+
+[patch.crates-io]
+bbox = { git = "https://github.com/dflemstr/bbox.git" }
+implicit3d = { git = "https://github.com/dflemstr/implicit3d.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tessellation"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["Henning Meyer <tutmann@gmail.com>"]
 edition = "2018"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use self::manifold_dual_contouring::ManifoldDualContouring;
 pub use self::mesh::Mesh;
 
 /// A Combination of alga::general::RealField and na::RealField.
-pub trait RealField: alga::general::RealField + na::RealField {}
+pub trait RealField: simba::scalar::RealField + na::RealField {}
 impl RealField for f64 {}
 impl RealField for f32 {}
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,4 +1,4 @@
-use alga::general::RealField;
+use simba::scalar::RealField;
 use nalgebra as na;
 use std::error::Error;
 use std::fmt;

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -1,4 +1,4 @@
-use alga::general::RealField;
+use simba::scalar::RealField;
 use nalgebra as na;
 use std::fmt::Debug;
 


### PR DESCRIPTION
The `alga` crate is deprecated and has been replaced by `simba`.  This PR also allows the introduction of a much newer `nalgebra` version which is pretty significant.

Depends on https://github.com/hmeyer/bbox/pull/3 and https://github.com/hmeyer/implicit3d/pull/2 for now, after which the `[patch]` section will be removed