### PR TITLE
Add GitHub Actions workflow for publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+name: Publish to crates.io
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automate publishing the crate to crates.io.

## Key Changes
- Added `.github/workflows/publish.yml` workflow file that:
  - Triggers on manual workflow dispatch (no automatic publishing)
  - Checks out the repository code
  - Installs the stable Rust toolchain
  - Publishes the crate to crates.io using the `CARGO_REGISTRY_TOKEN` secret

## Implementation Details
The workflow uses `dtolnay/rust-toolchain@stable` for reliable Rust toolchain installation and requires the `CARGO_REGISTRY_TOKEN` secret to be configured in the repository settings for authentication with crates.io.

https://claude.ai/code/session_01TPXKBqTbWimS93H4a9eoVT